### PR TITLE
Convert to stable API

### DIFF
--- a/block/blk-bpf-io-filter.h
+++ b/block/blk-bpf-io-filter.h
@@ -7,7 +7,7 @@ void io_filter_bpf_free(struct gendisk *disk);
 int io_filter_bpf_run(struct bio *bio);
 #else
 static inline void io_filter_bpf_free(struct gendisk *disk) { }
-static inline int io_filter_bpf_run(struct bio *bio) { return 1; }
+static inline int io_filter_bpf_run(struct bio *bio) { return IO_ALLOW; }
 #endif
 
 #endif	/* _BLK_BPF_IO_FILTER */

--- a/block/bpf_io_filter.c
+++ b/block/bpf_io_filter.c
@@ -17,10 +17,6 @@
 #define io_filter_rcu_dereference_progs(disk)	\
 	rcu_dereference_protected(disk->progs, lockdep_is_held(&disk->io_filter_lock))
 
-/*
-Need to build this out such that all, but only, necessary functions are
-allowed.
-
 static const struct bpf_func_proto *
 io_filter_func_proto(enum bpf_func_id func_id, const struct bpf_prog *prog)
 {
@@ -37,73 +33,21 @@ io_filter_func_proto(enum bpf_func_id func_id, const struct bpf_prog *prog)
 		return &bpf_map_pop_elem_proto;
 	case BPF_FUNC_map_peek_elem:
 		return &bpf_map_peek_elem_proto;
-	case BPF_FUNC_ktime_get_ns:
-		return &bpf_ktime_get_ns_proto;
-	case BPF_FUNC_tail_call:
-		return &bpf_tail_call_proto;
-	case BPF_FUNC_get_current_pid_tgid:
-		return &bpf_get_current_pid_tgid_proto;
-	case BPF_FUNC_get_current_task:
-		return &bpf_get_current_task_proto;
-	case BPF_FUNC_get_current_uid_gid:
-		return &bpf_get_current_uid_gid_proto;
-	case BPF_FUNC_get_current_comm:
-		return &bpf_get_current_comm_proto;
 	case BPF_FUNC_trace_printk:
-		return bpf_get_trace_printk_proto();
-	case BPF_FUNC_get_smp_processor_id:
-		return &bpf_get_smp_processor_id_proto;
-	case BPF_FUNC_get_numa_node_id:
-		return &bpf_get_numa_node_id_proto;
-	case BPF_FUNC_perf_event_read:
-		return &bpf_perf_event_read_proto;
-	case BPF_FUNC_probe_write_user:
-		return bpf_get_probe_write_proto();
-	case BPF_FUNC_current_task_under_cgroup:
-		return &bpf_current_task_under_cgroup_proto;
-	case BPF_FUNC_get_prandom_u32:
-		return &bpf_get_prandom_u32_proto;
-	case BPF_FUNC_probe_read_user:
-		return &bpf_probe_read_user_proto;
-	case BPF_FUNC_probe_read_kernel:
-		return &bpf_probe_read_kernel_proto;
-	case BPF_FUNC_probe_read:
-		return &bpf_probe_read_compat_proto;
-	case BPF_FUNC_probe_read_user_str:
-		return &bpf_probe_read_user_str_proto;
-	case BPF_FUNC_probe_read_kernel_str:
-		return &bpf_probe_read_kernel_str_proto;
-	case BPF_FUNC_probe_read_str:
-		return &bpf_probe_read_compat_str_proto;
-#ifdef CONFIG_CGROUPS
-	case BPF_FUNC_get_current_cgroup_id:
-		return &bpf_get_current_cgroup_id_proto;
-#endif
-	case BPF_FUNC_send_signal:
-		return &bpf_send_signal_proto;
-	case BPF_FUNC_perf_event_output:
-		return &bpf_perf_event_output_proto;
-	case BPF_FUNC_get_stackid:
-		return &bpf_get_stackid_proto;
-	case BPF_FUNC_get_stack:
-		return &bpf_get_stack_proto;
-	case BPF_FUNC_perf_event_read_value:
-		return &bpf_perf_event_read_value_proto;
-#ifdef CONFIG_BPF_KPROBE_OVERRIDE
-	case BPF_FUNC_override_return:
-		return &bpf_override_return_proto;
-#endif
+		if (capable(CAP_SYS_ADMIN))
+			return bpf_get_trace_printk_proto();
+		/* else fall through */
 	default:
 		return NULL;
 	}
 }
-*/
+
 
 const struct bpf_prog_ops io_filter_prog_ops = {
 };
 
 const struct bpf_verifier_ops io_filter_verifier_ops = {
-	.get_func_proto = bpf_tracing_func_proto,
+	.get_func_proto = io_filter_func_proto,
 	.is_valid_access = btf_ctx_access,
 };
 

--- a/include/linux/bpf_types.h
+++ b/include/linux/bpf_types.h
@@ -49,7 +49,7 @@ BPF_PROG_TYPE(BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE, raw_tracepoint_writable,
 BPF_PROG_TYPE(BPF_PROG_TYPE_TRACING, tracing,
 	      void *, void *)
 BPF_PROG_TYPE(BPF_PROG_TYPE_IO_FILTER, io_filter,
-	      void *, struct bio)
+	      struct bpf_io_request, struct bpf_io_request)
 #endif
 #ifdef CONFIG_CGROUP_BPF
 BPF_PROG_TYPE(BPF_PROG_TYPE_CGROUP_DEVICE, cg_dev,

--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -3951,4 +3951,13 @@ struct bpf_pidns_info {
 	__u32 pid;
 	__u32 tgid;
 };
+
+#define IO_ALLOW 1
+#define IO_BLOCK 0
+
+struct bpf_io_request {
+	__u64 sector_start;	/* first sector */
+	__u32 sector_cnt;	/* number of sectors */
+	__u32 opf;		/* bio->bi_opf */
+};
 #endif /* _UAPI__LINUX_BPF_H__ */

--- a/samples/bpf/Makefile
+++ b/samples/bpf/Makefile
@@ -55,6 +55,7 @@ tprogs-y += ibumad
 tprogs-y += hbm
 tprogs-y += io_filter
 tprogs-y += io_filter_progs
+tprogs-y += protect_gpt
 
 # Libbpf dependencies
 LIBBPF = $(TOOLS_PATH)/lib/bpf/libbpf.a
@@ -113,6 +114,7 @@ ibumad-objs := bpf_load.o ibumad_user.o $(TRACE_HELPERS)
 hbm-objs := bpf_load.o hbm.o $(CGROUP_HELPERS)
 io_filter-objs := bpf_load.o io_filter_user.o $(TRACE_HELPERS)
 io_filter_progs-objs := bpf_load.o io_filter_progs_user.o $(TRACE_HELPERS)
+protect_gpt-objs := bpf_load.o protect_gpt_user.o $(TRACE_HELPERS)
 
 # Tell kbuild to always build the programs
 always-y := $(tprogs-y)
@@ -177,6 +179,7 @@ always-y += xdpsock_kern.o
 always-y += io_filter_kern.o
 always-y += io_filter_allow_kern.o
 always-y += io_filter_block_kern.o
+always-y += protect_gpt_kern.o
 
 ifeq ($(ARCH), arm)
 # Strip all except -D__LINUX_ARM_ARCH__ option needed to handle linux

--- a/samples/bpf/io_filter_allow_kern.c
+++ b/samples/bpf/io_filter_allow_kern.c
@@ -5,8 +5,8 @@
 char _license[] SEC("license") = "GPL";
 
 SEC("io_filter")
-int filter_io(struct bio *b)
+int filter_io(struct bpf_io_request *io_req)
 {
-	return 1;
+	return IO_ALLOW;
 }
 

--- a/samples/bpf/io_filter_block_kern.c
+++ b/samples/bpf/io_filter_block_kern.c
@@ -5,8 +5,8 @@
 char _license[] SEC("license") = "GPL";
 
 SEC("io_filter")
-int filter_io(struct bio *b)
+int filter_io(struct bpf_io_request *io_req)
 {
-	return 0;
+	return IO_BLOCK;
 }
 

--- a/samples/bpf/io_filter_kern.c
+++ b/samples/bpf/io_filter_kern.c
@@ -5,9 +5,9 @@
 char _license[] SEC("license") = "GPL";
 
 SEC("io_filter")
-int filter_io(struct bio *b)
+int filter_io(struct bpf_io_request *io_req)
 {
 	bpf_printk("Filter_io\n", 15);
-	return 0;
+	return IO_BLOCK;
 }
 

--- a/samples/bpf/io_testing/test_protect_gpt.sh
+++ b/samples/bpf/io_testing/test_protect_gpt.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#WARNING: may overwrite GPT, use on scratch disk only
+#Tests attempts to write to various parts of disk
+#While program is attached, writes to GPT should be blocked while all other regions allowed
+
+echo "Running tests for protect_gpt bpf program"
+
+if [[ $# -ne 1 ]]; then
+	echo "Please enter device as argument"
+	exit 1
+fi
+
+TEST_DEV=$1
+GPT_SIZE=34	#number sectors in GPT
+SECTOR_SIZE=512	#bytes per sector
+
+#change to folder containing programs, 
+#protect_gpt needs to be run in same folder as protect_gpt_kern.o
+#TODO: update based on dir structure when added to xfstests
+cd ..
+
+#Load program:
+./protect_gpt $TEST_DEV protect_gpt${TEST_DEV//\//_} --attach 1> /dev/null
+
+if [[ $? -ne 0 ]]; then
+	echo "Failed to load protect_gpt program"
+	exit 1
+fi
+
+#Test: write to first GPT_SIZE blocks
+#	should fail
+dd if=/dev/zero of="$TEST_DEV" bs=$SECTOR_SIZE count=$GPT_SIZE oflag=direct &> /dev/null 
+
+if [[ $? -eq 0 ]]; then
+	echo "Failed test: program allowed writing to GPT"
+	./protect_gpt $TEST_DEV protect_gpt${TEST_DEV//\//_} --detach 1> /dev/null
+	exit 1
+fi
+
+#Test: write to last block of GPT and first block after GPT all in one IO request
+#	should fail
+dd if=/dev/zero of="$TEST_DEV" bs=$((2 * $SECTOR_SIZE)) seek=$((($GPT_SIZE-1) * $SECTOR_SIZE)) count=1 oflag=direct,seek_bytes &> /dev/null
+if [[ $? -eq 0 ]]; then
+	echo "Failed test: program allowed writing to last block of GPT"
+	./protect_gpt $TEST_DEV protect_gpt${TEST_DEV//\//_} --detach 1> /dev/null
+	exit 1
+fi
+
+#Test: write to block after first GPT_SIZE blocks
+#	should pass
+dd if=/dev/zero of="$TEST_DEV" bs=$SECTOR_SIZE seek=$GPT_SIZE count=1 oflag=direct &> /dev/null
+
+if [[ $? -ne 0 ]]; then
+	echo "Failed test: program blocked writing to non-GPT sector"
+	./protect_gpt $TEST_DEV protect_gpt${TEST_DEV//\//_} --detach 1> /dev/null
+	exit 1
+fi
+
+#Detach program
+./protect_gpt $TEST_DEV protect_gpt${TEST_DEV//\//_} --detach 1> /dev/null
+
+if [[ $? -ne 0 ]]; then
+	echo "Failed to detach protect_gpt program"
+	exit 1
+fi
+
+#Test: write to first GPT_SIZE blocks
+#	should pass
+dd if=/dev/zero of="$TEST_DEV" bs=$SECTOR_SIZE count=$GPT_SIZE oflag=direct &> /dev/null 
+
+if [[ $? -ne 0 ]]; then
+	echo "Failed test: program blocked writing to GPT after detach"
+	exit 1
+fi
+
+echo "All tests passed."
+exit 0

--- a/samples/bpf/protect_gpt_kern.c
+++ b/samples/bpf/protect_gpt_kern.c
@@ -1,0 +1,19 @@
+#include <linux/bpf.h>
+#include <linux/blk_types.h>
+#include "bpf/bpf_helpers.h"
+
+char _license[] SEC("license") = "GPL";
+
+#define GPT_SECTORS 34
+
+SEC("gpt_io_filter")
+int protect_gpt(struct bpf_io_request *io_req)
+{
+	/* within GPT and not a read operation */
+	if (io_req->sector_start < GPT_SECTORS && (io_req->opf & REQ_OP_MASK) != REQ_OP_READ)
+		return IO_BLOCK;
+
+	return IO_ALLOW;
+}
+
+

--- a/samples/bpf/protect_gpt_user.c
+++ b/samples/bpf/protect_gpt_user.c
@@ -1,0 +1,137 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <linux/bpf.h>
+#include <errno.h>
+#include "trace_helpers.h"
+#include "bpf_load.h"
+
+/*
+ * user program to load bpf program (protect_gpt_kern) to prevent writing to GUID
+ * parititon table
+ *
+ * argument 1: device where program will be attached (ie. /dev/sda)
+ * argument 2: name for pinned program
+ * argument 3: --attach or --detach to attach/detach program
+*/
+
+int attach(char* dev, char* path);
+int detach(char* dev, char* path);
+void usage(char* exec);
+
+int main(int argc, char **argv)
+{
+	char path[256];
+
+	if (argc != 4){
+		usage(argv[0]);
+		return 1;
+	}
+
+	strcpy(path, "/sys/fs/bpf/");
+	strcat(path, argv[2]);
+
+	if (strcmp(argv[3], "--attach") == 0)
+		return attach(argv[1], path);
+	else if (strcmp(argv[3], "--detach") == 0)
+		return detach(argv[1], path);
+	else {
+		fprintf(stderr, "Error: invalid flag, please specify --attach or --detach");
+		return 1;
+	}
+
+	return 1;
+}
+
+int attach(char* dev, char* path)
+{
+	struct bpf_object *obj;
+	int ret, devfd, progfd;
+
+	progfd = bpf_obj_get(path);
+	if (progfd >= 0) {
+		fprintf(stderr, "Error: object already pinned at given location (%s)\n", path);
+		return 1;
+	}
+
+	ret = bpf_prog_load("protect_gpt_kern.o",
+			    BPF_PROG_TYPE_IO_FILTER, &obj, &progfd);
+	if (ret) {
+		fprintf(stderr, "Error: failed to load program\n");
+		return 1;
+	}
+
+	devfd = open(dev, O_RDONLY);
+	if (devfd == -1) {
+		fprintf(stderr, "Error: failed to open block device %s\n", dev);
+		return 1;
+	}
+
+	ret = bpf_prog_attach(progfd, devfd, BPF_BIO_SUBMIT, 0);
+	if (ret) {
+		fprintf(stderr, "Error: failed to attach program to device\n");
+		close(devfd);
+		return 1;
+	}
+
+	ret = bpf_obj_pin(progfd, path);
+	if (ret != 0) {
+		fprintf(stderr, "Error pinning program: %s\n", strerror(errno));
+		fprintf(stderr, "Detaching program from device\n");
+
+		if(bpf_prog_detach2(progfd, devfd, BPF_BIO_SUBMIT))
+			fprintf(stderr, "Error: failed to detach program\n");
+
+		close(devfd);
+		return 1;
+	}
+
+	close(devfd);
+	printf("Attached protect_gpt program to device %s.\n", dev);
+	printf("Program pinned to %s.\n", path);
+	return 0;
+}
+
+int detach(char* dev, char* path)
+{
+	int ret, devfd, progfd;
+
+	progfd = bpf_obj_get(path);
+	if (progfd < 0) {
+		fprintf(stderr, "Error: failed to get pinned program from path %s\n", path);
+		return 1;
+	}
+
+	devfd = open(dev, O_RDONLY);
+	if (devfd == -1) {
+		fprintf(stderr, "Error: failed to open block device %s\n", dev);
+		return 1;
+	}
+
+	ret = bpf_prog_detach2(progfd, devfd, BPF_BIO_SUBMIT);
+	if (ret) {
+		fprintf(stderr, "Error: failed to detach program\n");
+		close(devfd);
+		return 1;
+	}
+
+	close(devfd);
+
+	ret = unlink(path);
+	if (ret < 0) {
+		fprintf(stderr, "Error unpinning map at %s: %s\n", path, strerror(errno));
+		return 1;
+	}
+
+	printf("Detached and unpinned program.\n");
+	return 0;
+}
+
+void usage(char* exec)
+{
+	printf("Usage:\n");
+	printf("\t %s <device> <prog name> --attach\n", exec);
+	printf("\t %s <device> <prog name> --detach\n", exec);
+}

--- a/tools/include/uapi/linux/bpf.h
+++ b/tools/include/uapi/linux/bpf.h
@@ -3951,4 +3951,13 @@ struct bpf_pidns_info {
 	__u32 pid;
 	__u32 tgid;
 };
+
+#define IO_ALLOW 1
+#define IO_BLOCK 0
+
+struct bpf_io_request {
+	__u64 sector_start;     /* first sector */
+	__u32 sector_cnt;       /* number of sectors */
+	__u32 opf;              /* bio->bi_opf */
+};
 #endif /* _UAPI__LINUX_BPF_H__ */


### PR DESCRIPTION
Convert IO_FILTER bpf program type to stable API.

Add sample program protect_gpt which filters write operations to the first 34 sectors. Add test_protect_gpt.sh which tests the protect_gpt sample program.